### PR TITLE
Change spellReplace implementation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gsgWordcloud
 Type: Package
 Title: Interface for Creating Wordclouds Faster
-Version: 2.1.4
+Version: 2.2.0
 Author: Matt Garber
 Maintainer: Matt Garber <mgarber@sas.upenn.edu>
 Description: Use this package to create wordclouds faster than the standard by hand process.

--- a/R/generate.R
+++ b/R/generate.R
@@ -9,20 +9,12 @@ generateWordCloudData <- function(txt,
                                   mergereplace = NULL,
                                   bestkeep = NULL,
                                   bestreplace = NULL) {
-    if (spellcheck) {
-        txt <- spellReplace(txt, keepWords = keepWords, replaceWords = replaceWords)
-        df <- freqForWordCloud(txt$text,
-                               bestkeep = bestkeep,
-                               bestreplace = bestreplace,
-                               mergekeep = mergekeep,
-                               mergereplace = mergereplace)
-    } else {
-        df <- freqForWordCloud(txt,
-                               bestkeep = bestkeep,
-                               bestreplace = bestreplace,
-                               mergekeep = mergekeep,
-                               mergereplace = mergereplace)
-    }
+    txt <- spellReplace(txt, keepWords = keepWords, replaceWords = replaceWords, spellcheck)
+    df <- freqForWordCloud(txt$text,
+                           bestkeep = bestkeep,
+                           bestreplace = bestreplace,
+                           mergekeep = mergekeep,
+                           mergereplace = mergereplace)
 
 
     out <- df[!is.na(df$best.source),]

--- a/man/generateWordCloudData.Rd
+++ b/man/generateWordCloudData.Rd
@@ -8,7 +8,7 @@ generateWordCloudData(txt, spellcheck = TRUE, combine = TRUE, name = "wordcloud_
 \arguments{
 \item{txt}{a character or character vector, the text data you wish to use}
 
-\item{spellcheck}{logical, whether or not to spellcheck the input. Defautls to \code{TRUE}}
+\item{spellcheck}{logical, whether or not to spellcheck the input. Defaults to \code{TRUE}. Custom-entered replacements will be made regardless.}
 \item{combine}{logical, whether or not to stem and combine the input. Defautls to \code{TRUE}}
 
 \item{name}{a character, the name of the folder to output the data to. Defaults to \code{wordcloud_text}}

--- a/man/gsgWordcloud.Rd
+++ b/man/gsgWordcloud.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/gsgWordcloud.R
 \docType{package}
 \name{gsgWordcloud}
+\alias{gsgWordcloud}
 \alias{gsgWordcloud-package}
 \title{API for Wordclouds}
 \description{

--- a/man/spellReplace.Rd
+++ b/man/spellReplace.Rd
@@ -4,7 +4,8 @@
 \alias{spellReplace}
 \title{Replace all misspelled words with either the suggested replacement or the specified replacement}
 \usage{
-spellReplace(txt, keepWords = NULL, replaceWords = NULL)
+spellReplace(txt, keepWords = NULL, replaceWords = NULL,
+  spellcheck = TRUE)
 }
 \arguments{
 \item{txt}{a character or character vector to be spell checked}
@@ -12,6 +13,8 @@ spellReplace(txt, keepWords = NULL, replaceWords = NULL)
 \item{keepWords}{a character vector of words to not replace with the inferred best word}
 
 \item{replaceWords}{a character vector of the same length as \code{keepWords} of the user-defined replacements for the given words}
+
+\item{spellcheck}{logical, defaults to \code{TRUE}. If \code{TRUE}, does an automatic spell check with hunspell. If \code{FALSE}, makes only the user entered replacements.}
 }
 \value{
 A list with two fields: \code{text}, a character or character vector with only single spaces, and \code{replacements}, a dataframe documenting each word replaced and what it was replaced by.
@@ -21,7 +24,4 @@ Replace all misspelled words with either the suggested replacement or the specif
 }
 \note{
 This will sometimes remove some/all punctuation and other times may add punctuation.
-}
-\examples{
-collapseWS("hello    world") # "hello world"
 }


### PR DESCRIPTION
No longer splits and flattens input by word for replacements. Now replaces using gsub() logic with a word matching regular expression:

- This regex is intended to match an inputted word to a full word, not followed by an alphanumeric character, not followed by a hyphen, and not followed by an apostrophe. This allows matches for contractions and combinations.
